### PR TITLE
Restored compatibility with PHP 5.4.

### DIFF
--- a/src/Nuvei/Api/Service/BaseService.php
+++ b/src/Nuvei/Api/Service/BaseService.php
@@ -247,13 +247,17 @@ class BaseService implements ServiceInterface
     {
         if (!$checksumParametersOrder && $processAdditionalParams) {
             $paramKeys = array_keys($params);
-            $checksumParametersOrder = [
-                'merchantId',
-                'merchantSiteId',
-                ...$paramKeys,
-                'timeStamp',
-                'checksum'
-            ];
+            $checksumParametersOrder = array_merge(
+                [
+                    'merchantId',
+                    'merchantSiteId',
+                ],
+                $paramKeys,
+                [
+                    'timeStamp',
+                    'checksum'
+                ]
+            );
         }
         if (!$checksumParametersOrder) {
             $checksumParametersOrder = $mandatoryFields;

--- a/tests/WithdrawalRequestsTest.php
+++ b/tests/WithdrawalRequestsTest.php
@@ -68,7 +68,7 @@ class WithdrawalRequestsTest extends TestCase
         $this->assertThat($response, $this->logicalOr(
             $this->arrayHasKey('merchantId'),
             $this->arrayHasKey('merchantSiteId'),
-            $this->arrayHasKey('transactionsDetailList'),
+            $this->arrayHasKey('transactionsDetailList')
         ));
         $this->assertEquals('SUCCESS', $response['status']);
     }


### PR DESCRIPTION
Done so by removing the trailing function comma in WithdrawalRequestsTest (as this is PHP 8.0+), and replacing the spread operator (PHP 7.4+) usage in BaseService with array_merge().